### PR TITLE
Add support for regex + fix casting 0 to Number

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,12 +70,15 @@ function comparisonToMongo(key, value) {
         parts[3].split(',').forEach(function(value) {
             array.push(typedValue(value))
         })
+        var regex = array[0].match(/^\/(.*)\/(i?)$/);
         if (array.length > 1) {
             value = {}
             op = (op == '=') ? '$in' : '$nin'
             value[op] = array
         } else if (op == '!=') {
             value = { '$ne': array[0] }
+        } else if (regex) {
+            value = { '$regex': new RegExp(regex[1], regex[2]) };
         } else {
             value = array[0]
         }

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function comparisonToMongo(key, value) {
         parts[3].split(',').forEach(function(value) {
             array.push(typedValue(value))
         })
-        var regex = array[0].match(/^\/(.*)\/(i?)$/);
+        var regex = value.match(/^\/(.*)\/(i?)$/);
         if (array.length > 1) {
             value = {}
             op = (op == '=') ? '$in' : '$nin'

--- a/index.js
+++ b/index.js
@@ -151,6 +151,7 @@ function queryOptionsToMongo(query, options) {
 }
 
 module.exports = function(query, options) {
+    query = query || {};
     options = options || {}
 
     if (!options.ignore) {

--- a/index.js
+++ b/index.js
@@ -38,10 +38,17 @@ function sortToMongo(sort) {
 
 // Convert String to Number, Date, or Boolean if possible
 function typedValue(value) {
-    var n = Number(value)
-    if (n && n != NaN) return n
-    if (iso8601.test(value)) return new Date(value)
-    return (value == 'true') || ((value == 'false') ? false : value)
+  if (value === 'true') {
+    return true;
+  } else if (value === 'false') {
+    return false;
+  } else if (iso8601.test(value)) {
+    return new Date(value);
+  } else if (!isNaN(Number(value))) {
+    return Number(value);
+  }
+
+  return value;
 }
 
 // Convert a key/value pair split at an equals sign into a mongo comparison.

--- a/index.js
+++ b/index.js
@@ -38,7 +38,11 @@ function sortToMongo(sort) {
 
 // Convert String to Number, Date, or Boolean if possible
 function typedValue(value) {
-  if (value === 'true') {
+  var regex = value.match(/^\/(.*)\/(i?)$/);
+
+  if (regex) {
+    return new RegExp(regex[1], regex[2]);
+  } else if (value === 'true') {
     return true;
   } else if (value === 'false') {
     return false;
@@ -70,15 +74,12 @@ function comparisonToMongo(key, value) {
         parts[3].split(',').forEach(function(value) {
             array.push(typedValue(value))
         })
-        var regex = value.match(/^\/(.*)\/(i?)$/);
         if (array.length > 1) {
             value = {}
             op = (op == '=') ? '$in' : '$nin'
             value[op] = array
         } else if (op == '!=') {
             value = { '$ne': array[0] }
-        } else if (regex) {
-            value = { '$regex': new RegExp(regex[1], regex[2]) };
         } else {
             value = array[0]
         }

--- a/test/qs.js
+++ b/test/qs.js
@@ -10,14 +10,19 @@ describe("query-to-mongo(query,{paser: qs}) =>", function () {
             assert.deepEqual(results.criteria, {foo: {bar: "value"}})
         })
         it("should create numeric criteria", function () {
-            var results = q2m("foo[i]=10&foo[f]=1.2", {parser: qs})
+            var results = q2m("foo[i]=10&foo[f]=1.2&foo[z]=0", {parser: qs})
             assert.ok(results.criteria)
-            assert.deepEqual(results.criteria, {foo:{"i": 10, "f": 1.2}})
+            assert.deepEqual(results.criteria, {foo:{"i": 10, "f": 1.2, "z": 0}})
         })
         it("should create boolean criteria", function () {
             var results = q2m("foo[t]=true&foo[f]=false", {parser: qs})
             assert.ok(results.criteria)
             assert.deepEqual(results.criteria, {foo:{t: true, f: false}})
+        })
+        it("should create regex criteria", function () {
+            var results = q2m("foo[r]=/regex/&foo[ri]=/regexi/i", {parser: qs})
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {foo:{r: /regex/, ri: /regexi/i}})
         })
         // can't create comparisons for embedded documents
         it("shouldn't ignore deep criteria", function () {

--- a/test/query.js
+++ b/test/query.js
@@ -9,14 +9,19 @@ describe("query-to-mongo(query) =>", function () {
             assert.deepEqual(results.criteria, {field: "value"})
         })
         it("should create numeric criteria", function () {
-            var results = q2m("i=10&f=1.2")
+            var results = q2m("i=10&f=1.2&z=0")
             assert.ok(results.criteria)
-            assert.deepEqual(results.criteria, {"i": 10, "f": 1.2})
+            assert.deepEqual(results.criteria, {"i": 10, "f": 1.2, "z": 0})
         })
         it("should create boolean criteria", function () {
             var results = q2m("t=true&f=false")
             assert.ok(results.criteria)
             assert.deepEqual(results.criteria, {t: true, f: false})
+        })
+        it("should create regex criteria", function () {
+            var results = q2m("r=/regex/&ri=/regexi/i")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {r: /regex/, ri: /regexi/i})
         })
         it("should create Date criteria from YYYY-MM", function () {
             var results = q2m("d=2010-04"), expect


### PR DESCRIPTION
- Add support for regex (and i modifier) matching (ie, `foo=/\d+/&foo=/[a-z]{5}/i`)
- Fix casting 0 to Number (ie, `?balance>0` would not work)
- Add test cases
