### PR TITLE
Check for field present ($exists) and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Any query parameters other then _fields_, _omit_, _sort_, _offset_, and _limit_ 
 * Multiple not-equals comparisons are merged into a `$nin` operator. For example, `id!=a&id!=b` yields `{id:{$nin:['a','b']}}`.
 * Comma separated values in equals or not-equals yeild an `$in` or `$nin` operator. For example, `id=a,b` yields `{id:{$in:['a','b']}}`.
 * Regex patterns. For example, `name=/^john/i` yields `{id: /^john/i}`.
+* Parameters without a value check that the field is present. For example, `foo&bar=10` yields `{foo: {$exists: true}, bar: 10}`.
+* Parameters prefixed with a _not_ (!) and without a value check that the field is not present. For example, `!foo&bar=10` yields `{foo: {$exists: false}, bar: 10}`.
 
 ### A note on embedded documents
 Comparisons on embedded documents should use mongo's [dot notation](http://docs.mongodb.org/manual/reference/glossary/#term-dot-notation) instead of express's 'extended' [query parser](https://www.npmjs.com/package/qs) (Use `foo.bar=value` instead of `foo[bar]=value`).
@@ -143,6 +145,4 @@ npm test
 ```
 
 ## Todo
-* Add support for `$exists`. Arguments w/o a value (ie., `foo&bar=10`) would yield `{'foo':{$exists:true}, 'bar':...}`; prefixed with not(!) (ie., `!foo&bar=10`) would yield `{'foo': {$exists: false}, 'bar': ...}`.
-* Add support for `$regex`. Values with slashes (field=/pattern/) would result in `{'field':{$regex: /pattern/}}`. Don't forget case-insensitive patterns (/pattern/i).
 * Add support for forced string comparison; value in quotes (`field='10'`) would force a string compare. Should allow for string with embedded comma (`field='a,b'`).

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Any query parameters other then _fields_, _omit_, _sort_, _offset_, and _limit_ 
 * Regex patterns. For example, `name=/^john/i` yields `{id: /^john/i}`.
 * Parameters without a value check that the field is present. For example, `foo&bar=10` yields `{foo: {$exists: true}, bar: 10}`.
 * Parameters prefixed with a _not_ (!) and without a value check that the field is not present. For example, `!foo&bar=10` yields `{foo: {$exists: false}, bar: 10}`.
-* Supports some of the named comparision operators ($type, ...).  For example, `foo:type=string`, yeilds `{ foo: {$type: 'string} }`.
+* Supports some of the named comparision operators ($type, $size).  For example, `foo:type=string`, yeilds `{ foo: {$type: 'string} }`.
 ### A note on embedded documents
 Comparisons on embedded documents should use mongo's [dot notation](http://docs.mongodb.org/manual/reference/glossary/#term-dot-notation) instead of express's 'extended' [query parser](https://www.npmjs.com/package/qs) (Use `foo.bar=value` instead of `foo[bar]=value`).
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Any query parameters other then _fields_, _omit_, _sort_, _offset_, and _limit_ 
 * Regex patterns. For example, `name=/^john/i` yields `{id: /^john/i}`.
 * Parameters without a value check that the field is present. For example, `foo&bar=10` yields `{foo: {$exists: true}, bar: 10}`.
 * Parameters prefixed with a _not_ (!) and without a value check that the field is not present. For example, `!foo&bar=10` yields `{foo: {$exists: false}, bar: 10}`.
-* Supports some of the named comparision operators ($type, $size).  For example, `foo:type=string`, yeilds `{ foo: {$type: 'string} }`.
+* Supports some of the named comparision operators ($type, $size and $all).  For example, `foo:type=string`, yeilds `{ foo: {$type: 'string} }`.
 ### A note on embedded documents
 Comparisons on embedded documents should use mongo's [dot notation](http://docs.mongodb.org/manual/reference/glossary/#term-dot-notation) instead of express's 'extended' [query parser](https://www.npmjs.com/package/qs) (Use `foo.bar=value` instead of `foo[bar]=value`).
 
@@ -146,3 +146,7 @@ npm test
 
 ## Todo
 * Add support for forced string comparison; value in quotes (`field='10'`) would force a string compare. Should allow for string with embedded comma (`field='a,b'`).
+* Geospatial search
+* $text searches
+* $mod comparision
+* Bitwise comparisions

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Any query parameters other then _fields_, _omit_, _sort_, _offset_, and _limit_ 
 * Regex patterns. For example, `name=/^john/i` yields `{id: /^john/i}`.
 * Parameters without a value check that the field is present. For example, `foo&bar=10` yields `{foo: {$exists: true}, bar: 10}`.
 * Parameters prefixed with a _not_ (!) and without a value check that the field is not present. For example, `!foo&bar=10` yields `{foo: {$exists: false}, bar: 10}`.
-
+* Supports some of the named comparision operators ($type, ...).  For example, `foo:type=string`, yeilds `{ foo: {$type: 'string} }`.
 ### A note on embedded documents
 Comparisons on embedded documents should use mongo's [dot notation](http://docs.mongodb.org/manual/reference/glossary/#term-dot-notation) instead of express's 'extended' [query parser](https://www.npmjs.com/package/qs) (Use `foo.bar=value` instead of `foo[bar]=value`).
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ function typedValue(value) {
 // + f('key','value') => {key:'key',value:'value'}
 // + f('key>','value') => {key:'key',value:{$gte:'value'}}
 // + f('key') => {key:'key',value:{$exists: true}}
-// + f('!key') => {key:'key',value:{$exists: falseS}}
+// + f('!key') => {key:'key',value:{$exists: false}}
+// + f('key:op','value') => {key: 'key', value:{ $op: value}}
 function comparisonToMongo(key, value) {
     var join = (value == '') ? key : key.concat('=', value)
     var parts = join.match(/^(!?[^><!=:]+)(?:([><]=?|!?=|:.+=)(.+))?$/)
@@ -91,6 +92,10 @@ function comparisonToMongo(key, value) {
         } else {
             value = array[0]
         }
+    } else if (op[0] == ':' && op[op.length - 1] == '=') {
+        op = '$' + op.substr(1, op.length - 2)
+        value = { }
+        value[op] = typedValue(parts[3])
     } else {
         value = typedValue(parts[3])
         if (op == '>') value = {'$gt': value}

--- a/index.js
+++ b/index.js
@@ -94,8 +94,12 @@ function comparisonToMongo(key, value) {
         }
     } else if (op[0] == ':' && op[op.length - 1] == '=') {
         op = '$' + op.substr(1, op.length - 2)
+        var array = []
+        parts[3].split(',').forEach(function(value) {
+            array.push(typedValue(value))
+        })
         value = { }
-        value[op] = typedValue(parts[3])
+        value[op] = array.length == 1 ? array[0] : array
     } else {
         value = typedValue(parts[3])
         if (op == '>') value = {'$gt': value}

--- a/index.js
+++ b/index.js
@@ -60,16 +60,24 @@ function typedValue(value) {
 // for example:
 // + f('key','value') => {key:'key',value:'value'}
 // + f('key>','value') => {key:'key',value:{$gte:'value'}}
+// + f('key') => {key:'key',value:{$exists: true}}
+// + f('!key') => {key:'key',value:{$exists: falseS}}
 function comparisonToMongo(key, value) {
     var join = (value == '') ? key : key.concat('=', value)
-    var parts = join.match(/([^><!=]+)([><]=?|!?=)(.+)/)
+    var parts = join.match(/^(!?[^><!=:]+)(?:([><]=?|!?=|:.+=)(.+))?$/)
     var op, hash = {}
     if (!parts) return null
 
     key = parts[1]
     op = parts[2]
 
-    if (op == '=' || op == '!=') {
+    if (!op) {
+        if (key[0] != '!') value = { '$exists': true }
+        else {
+            key = key.substr(1)
+            value = { '$exists': false }
+        }
+    } else if (op == '=' || op == '!=') {
         var array = []
         parts[3].split(',').forEach(function(value) {
             array.push(typedValue(value))
@@ -115,12 +123,16 @@ function queryCriteriaToMongo(query, options) {
             deep = (typeof query[key] === 'object' && !hasOrdinalKeys(query[key]))
 
             if (deep) {
-                hash[key] = queryCriteriaToMongo(query[key])
+                p = {
+                    key: key,
+                    value: queryCriteriaToMongo(query[key])
+                }
             } else {
                 p = comparisonToMongo(key, query[key])
-                if (p) {
-                    hash[p.key] = p.value
-                }
+            }
+
+            if (p) {
+                hash[p.key] = p.value
             }
         }
     }

--- a/test/query.js
+++ b/test/query.js
@@ -147,6 +147,16 @@ describe("query-to-mongo(query) =>", function () {
             assert.ok(results.criteria)
             assert.deepEqual(results.criteria, {a: {"$exists": false}, b: 10})
         })
+        it("should create $type criteria with BSON type number", function () {
+            var results = q2m("field:type=2")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {field: {$type: 2} })
+        })
+        it("should create $type criteria with BSON type name", function () {
+            var results = q2m("field:type=string")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {field: {$type: "string"} })
+        })
     })
 
     describe(".options", function () {

--- a/test/query.js
+++ b/test/query.js
@@ -128,7 +128,7 @@ describe("query-to-mongo(query) =>", function () {
             assert.deepEqual(results.criteria, {field: {"$nin": ["a","b"]}})
         })
         it("should ignore criteria", function () {
-            var results = q2m("field=value&envelope=true&&offset=0&limit=10&fields=id,name&sort=name", { ignore: ['envelope']})
+            var results = q2m("field=value&envelope=true&&offset=0&limit=10&fields=id&sort=name", { ignore: ['envelope']})
             assert.ok(results.criteria)
             assert.notOk(results.criteria.envelope, "envelope")
             assert.notOk(results.criteria.skip, "offset")
@@ -136,6 +136,16 @@ describe("query-to-mongo(query) =>", function () {
             assert.notOk(results.criteria.fields, "fields")
             assert.notOk(results.criteria.sort, "sort")
             assert.deepEqual(results.criteria, {field: "value"})
+        })
+        it("should create $exists true criteria", function () {
+            var results = q2m("a&b=10&c", { ignore: ['c']})
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {a: {"$exists": true}, b: 10})
+        })
+        it("should create $exists false criteria", function () {
+            var results = q2m("!a&b=10&c", { ignore: ['c']})
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {a: {"$exists": false}, b: 10})
         })
     })
 

--- a/test/query.js
+++ b/test/query.js
@@ -162,6 +162,11 @@ describe("query-to-mongo(query) =>", function () {
             assert.ok(results.criteria)
             assert.deepEqual(results.criteria, {array: {$size: 2} })
         })
+        it("should create $all criteria", function () {
+            var results = q2m("array:all=50,60")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {array: {$all: [50, 60] } })
+        })
     })
 
     describe(".options", function () {

--- a/test/query.js
+++ b/test/query.js
@@ -157,6 +157,11 @@ describe("query-to-mongo(query) =>", function () {
             assert.ok(results.criteria)
             assert.deepEqual(results.criteria, {field: {$type: "string"} })
         })
+        it("should create $size criteria", function () {
+            var results = q2m("array:size=2")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {array: {$size: 2} })
+        })
     })
 
     describe(".options", function () {


### PR DESCRIPTION
Support for $exists, $type, $size and $all.  Named operators start with `:` and end with `=`.  For example, `?array:size=2` matches when `array.length == 2`.

`foo` is equivalent `foo:exists=true` and `'!foo` to `foo:exists:false`.
