### PR TITLE
Forced string comparison; value in single or double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Any query parameters other then _fields_, _omit_, _sort_, _offset_, and _limit_ 
 * Multiple not-equals comparisons are merged into a `$nin` operator. For example, `id!=a&id!=b` yields `{id:{$nin:['a','b']}}`.
 * Comma separated values in equals or not-equals yeild an `$in` or `$nin` operator. For example, `id=a,b` yields `{id:{$in:['a','b']}}`.
 * Regex patterns. For example, `name=/^john/i` yields `{id: /^john/i}`.
+* Supports for forced string comparison; value in single or double quotes (`field='10'` or `field="10"`) would force a string compare. Should allow for string with embedded comma (`field="a,b"`) and (`field="that's all folks"`).
 
 ### A note on embedded documents
 Comparisons on embedded documents should use mongo's [dot notation](http://docs.mongodb.org/manual/reference/glossary/#term-dot-notation) instead of express's 'extended' [query parser](https://www.npmjs.com/package/qs) (Use `foo.bar=value` instead of `foo[bar]=value`).
@@ -145,4 +146,3 @@ npm test
 ## Todo
 * Add support for `$exists`. Arguments w/o a value (ie., `foo&bar=10`) would yield `{'foo':{$exists:true}, 'bar':...}`; prefixed with not(!) (ie., `!foo&bar=10`) would yield `{'foo': {$exists: false}, 'bar': ...}`.
 * Add support for `$regex`. Values with slashes (field=/pattern/) would result in `{'field':{$regex: /pattern/}}`. Don't forget case-insensitive patterns (/pattern/i).
-* Add support for forced string comparison; value in quotes (`field='10'`) would force a string compare. Should allow for string with embedded comma (`field='a,b'`).

--- a/index.js
+++ b/index.js
@@ -39,9 +39,12 @@ function sortToMongo(sort) {
 // Convert String to Number, Date, or Boolean if possible
 function typedValue(value) {
   var regex = value.match(/^\/(.*)\/(i?)$/);
+  var quotedString = value.match(/(["'])(?:\\\1|.)*?\1/);
 
   if (regex) {
     return new RegExp(regex[1], regex[2]);
+  } else if (quotedString) {
+    return quotedString[0].substr(1, quotedString[0].length - 2);
   } else if (value === 'true') {
     return true;
   } else if (value === 'false') {
@@ -53,6 +56,19 @@ function typedValue(value) {
   }
 
   return value;
+}
+
+// Convert a comma separated string value to an array of values.  Commas
+// in a quoted string are ignored.
+function typedValues(svalue) {
+    var commaSplit = /("[^"]*")|('[^']*')|([^,]+)/g
+    var values = []
+    svalue
+        .match(commaSplit)
+        .forEach(function(value) {
+            values.push(typedValue(value))
+        })
+    return values;
 }
 
 // Convert a key/value pair split at an equals sign into a mongo comparison.
@@ -70,10 +86,7 @@ function comparisonToMongo(key, value) {
     op = parts[2]
 
     if (op == '=' || op == '!=') {
-        var array = []
-        parts[3].split(',').forEach(function(value) {
-            array.push(typedValue(value))
-        })
+        var array = typedValues(parts[3]);
         if (array.length > 1) {
             value = {}
             op = (op == '=') ? '$in' : '$nin'

--- a/test/qs.js
+++ b/test/qs.js
@@ -30,6 +30,11 @@ describe("query-to-mongo(query,{paser: qs}) =>", function () {
             assert.ok(results.criteria)
             assert.deepEqual(results.criteria, {field: "value", foo: {envelope: true}})
         })
+        it("should create string criteria when forced with a quote", function () {
+            var results = q2m("a='10'&b=\'11\'&c='a,b'&d=10,11&z=\"that's all folks\"", {parser: qs})
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {a: "10", b: "11", c: "a,b", d: {$in: [10, 11]}, z: "that's all folks"})
+        })
     })
 
     describe(".options", function () {

--- a/test/query.js
+++ b/test/query.js
@@ -137,6 +137,11 @@ describe("query-to-mongo(query) =>", function () {
             assert.notOk(results.criteria.sort, "sort")
             assert.deepEqual(results.criteria, {field: "value"})
         })
+        it("should create forced string criteria", function () {
+            var results = q2m("s='a,b'")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {s: "a,b"})
+        })
     })
 
     describe(".options", function () {


### PR DESCRIPTION
`field='10'` or `field="10"` would force a string compare. 

Allows string with embedded comma `field="a,b"`.

**TODO** escaping or double quoting, `='That\'s all folks'` or `='That''s all folks'`
