### PR TITLE
Fix numeric criteria exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function typedValue(value) {
     return true;
   } else if (value === 'false') {
     return false;
-  } else if (iso8601.test(value)) {
+  } else if (iso8601.test(value) && value.length !== 4) {
     return new Date(value);
   } else if (!isNaN(Number(value))) {
     return Number(value);

--- a/test/query.js
+++ b/test/query.js
@@ -145,6 +145,11 @@ describe("query-to-mongo(query) =>", function () {
             assert.ok(results.criteria)
             assert.deepEqual(results.criteria, {s: "a,b"})
         })
+        it("should create numeric criteria from YYYY exception", function () {
+            var results = q2m("d=2016")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {d: 2016})
+        })
     })
 
     describe(".options", function () {


### PR DESCRIPTION
From the README

> Values that are dates are compared as dates (except for YYYY which matches the number rule).
