### PR TITLE
Modified use of hasOwnProperty to instead call it from Object.prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function queryCriteriaToMongo(query, options) {
     var hash = {}, p, v, deep
     options = options || {}
     for (var key in query) {
-        if (query.hasOwnProperty(key) && (!options.ignore || options.ignore.indexOf(key) == -1)) {
+        if (Object.prototype.hasOwnProperty.call(query, key) && (!options.ignore || options.ignore.indexOf(key) == -1)) {
             deep = (typeof query[key] === 'object' && !hasOrdinalKeys(query[key]))
 
             if (deep) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-to-mongo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Convert query parameters into mongo query criteria and options.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
`hasOwnProperty` is no longer inherited in objects created by the core `querystring` module in recent versions of Node.js. See [here](https://github.com/tj/node-querystring/issues/61). This change fixes this problem.

Here's the error thrown in Node v6.9.1:

```
TypeError: query.hasOwnProperty is not a function
```