### PR TITLE
Range queries will now be parsed right

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,11 @@ function queryCriteriaToMongo(query, options) {
             }
 
             if (p) {
-                hash[p.key] = p.value
+                if (!hash[p.key]) {
+                    hash[p.key] = p.value;
+                } else {
+                    hash[p.key] = Object.assign(hash[p.key], p.value);
+                }
             }
         }
     }

--- a/test/query.js
+++ b/test/query.js
@@ -100,6 +100,16 @@ describe("query-to-mongo(query) =>", function () {
             assert.ok(results.criteria)
             assert.deepEqual(results.criteria, {field: {"$nin": ["a","b"]}})
         })
+        it("should create mixed criteria", function () {
+            var results = q2m("field!=10&field!=20&field>3")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {field: {"$nin": [10,20], "$gt": 3}})
+        })
+        it("should create range criteria",function () {
+            var results = q2m("field>=10&field<=20")
+            assert.ok(results.criteria)
+            assert.deepEqual(results.criteria, {field: {"$gte": 10, "$lte": 20}})
+        })
         it("should ignore criteria", function () {
             var results = q2m("field=value&envelope=true&&offset=0&limit=10&fields=id&sort=name", { ignore: ['envelope']})
             assert.ok(results.criteria)


### PR DESCRIPTION
Before:
```js
q2m('field>=1&field<=2'); // {field: {$lte: 2}}
```
Now:
```js
q2m('field>=1&field<=2'); // {field: {$gte: 1, $lte: 2}}
```

Node 0.12 [is not supported anymore](https://github.com/nodejs/LTS), so `Object.assign` was used.