### PR TITLE
add $ at the beginning of all the operators' name for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # query-to-mongo
 Node.js package to convert query parameters into a [mongo](https://www.mongodb.org) query criteria and options
 
-For example, a query such as: `name=john&age>21&fields=name,age&sort=name,-age&offset=10&limit=10` becomes the following hash:
+For example, a query such as: `name=john&age>21&$fields=name,age&$sort=name,-age&$offset=10&$limit=10` becomes the following hash:
 
 ```javascript
 {
@@ -24,7 +24,7 @@ var q2m = require('query-to-mongo')
 var mongoskin = require('mongoskin')
 var db = mongoskin.db('mongodb://localhost:27027/mydb')
 var collection = db.collection('mycollection')
-var query = q2m('name=john&age>13&limit=20')
+var query = q2m('name=john&age>13&$limit=20')
 collection.find(query.criteria, query.options).toArray(function(err, results) {
   ...
 })
@@ -47,7 +47,7 @@ Convert the query portion of a url to a mongo query.
 
 ```javascript
 var queryToMongo = require('query-to-mongo')
-var query = queryToMongo('name=john&age>21&limit=10')
+var query = queryToMongo('name=john&age>21&$limit=10')
 console.log(query)
 ```
 
@@ -59,7 +59,7 @@ console.log(query)
 
 #### options:
 * **maxLimit** The maximum limit (default is none)
-* **ignore** List of criteria to ignore in addition to those used for query options ("fields", "sort", "offset", "limit")
+* **ignore** List of criteria to ignore in addition to those used for query options ("$fields", "$sort", "$offset", "$limit")
 * **parser** Query parser to use instead of _querystring_. Must implement `parse(string)` and `stringify(obj)`.
 
 #### returns:
@@ -72,15 +72,15 @@ Calculate relative links given the base url and totalCount. Can be used to popul
 
 ```javascript
 var queryToMongo = require('query-to-mongo')
-var query = queryToMongo('name=john&age>21&offset=20&limit=10')
+var query = queryToMongo('name=john&age>21&$offset=20&$limit=10')
 console.log(query.links('http://localhost/api/v1/users', 100))
 ```
 
 ```javascript
-{ prev: 'http://localhost/api/v1/users?name=john&age%3E21=&offset=10&limit=10',
-  first: 'http://localhost/api/v1/users?name=john&age%3E21=&offset=0&limit=10',
-  next: 'http://localhost/api/v1/users?name=john&age%3E21=&offset=30&limit=10',
-  last: 'http://localhost/api/v1/users?name=john&age%3E21=&offset=90&limit=10' }
+{ prev: 'http://localhost/api/v1/users?name=john&age%3E21=&%24offset=10&%24limit=10',
+  first: 'http://localhost/api/v1/users?name=john&age%3E21=&%24offset=0&%24limit=10',
+  next: 'http://localhost/api/v1/users?name=john&age%3E21=&%24offset=30&%24limit=10',
+  last: 'http://localhost/api/v1/users?name=john&age%3E21=&%24offset=90&%24limit=10' }
 ```
 
 ## Use
@@ -90,7 +90,7 @@ The module is intended for use by express routes, and so takes a parsed query as
 ```
 var querystring = require('querystring')
 var q2m = require('query-to-mongo')
-var query = 'name=john&age>21&fields=name,age&sort=name,-age&offset=10&limit=10'
+var query = 'name=john&age>21&$fields=name,age&$sort=name,-age&$offset=10&$limit=10'
 var q = q2m(querystring.parse(query))
 ```
 
@@ -106,13 +106,13 @@ router.get('/api/v1/mycollection', function(req, res, next) {
 The format for arguments was inspired by item #7 in [this article](http://blog.mwaysolutions.com/2014/06/05/10-best-practices-for-better-restful-api/) about best practices for RESTful APIs.
 
 ### Field selection
-The _fields_ argument is a comma separated list of field names to include in the results. For example `fields=name,age` results in a _option.fields_ value of `{'name':true,'age':true}`. If no fields are specified then _option.fields_ is null, returning full documents as results.
+The _fields_ argument is a comma separated list of field names to include in the results. For example `$fields=name,age` results in a _option.fields_ value of `{'name':true,'age':true}`. If no fields are specified then _option.fields_ is null, returning full documents as results.
 
-The _omit_ argument is a comma separated list of field names to exclude in the results. For example `omit=name,age` results in a _option.fields_ value of `{'name':false,'age':false}`. If no fields are specified then _option.fields_ is null, returning full documents as results.
+The _omit_ argument is a comma separated list of field names to exclude in the results. For example `$omit=name,age` results in a _option.fields_ value of `{'name':false,'age':false}`. If no fields are specified then _option.fields_ is null, returning full documents as results.
 
 Note that either _fields_ or _omit_ can be used.  If both are specified then _omit_ takes precedence and the _fields_ entry is ignored.  Mongo will not accept a mix of true and false fields
 ### Sorting
-The _sort_ argument is a comma separated list of fields to sort the results by. For example `sort=name,-age` results in a _option.sort_ value of `{'name':1,'age':-1}`. If no sort is specified then _option.sort_ is null and the results are not sorted.
+The _sort_ argument is a comma separated list of fields to sort the results by. For example `$sort=name,-age` results in a _option.sort_ value of `{'name':1,'age':-1}`. If no sort is specified then _option.sort_ is null and the results are not sorted.
 
 ### Paging
 The _offset_ and _limit_ arguments indicate the subset of the full results to return. By default, the full results are returned. If _limit_ is set and the total count is obtained for the query criteria, pagination links can be generated:
@@ -127,10 +127,10 @@ For example, if _offset_ was 20, _limit_ was 10, and _count_ was 95, the followi
 
 ```
 {
-   'prev': 'http://localhost/api/v1/mycollection?offset=10&limit=10',
-   'first': `http://localhost/api/v1/mycollection?offset=0&limit=10`,
-   'next': 'http://localhost/api/v1/mycollection?offset=30&limit=10',
-   'last': 'http://localhost/api/v1/mycollection?offset=90&limit=10'
+   'prev': 'http://localhost/api/v1/mycollection?%24offset=10&%24limit=10',
+   'first': `http://localhost/api/v1/mycollection?%24offset=0&%24limit=10`,
+   'next': 'http://localhost/api/v1/mycollection?%24offset=30&%24limit=10',
+   'last': 'http://localhost/api/v1/mycollection?%24offset=90&%24limit=10'
 }
 ```
 
@@ -157,7 +157,7 @@ Any query parameters other then _fields_, _omit_, _sort_, _offset_, and _limit_ 
 * Parameters without a value check that the field is present. For example, `foo&bar=10` yields `{foo: {$exists: true}, bar: 10}`.
 * Parameters prefixed with a _not_ (!) and without a value check that the field is not present. For example, `!foo&bar=10` yields `{foo: {$exists: false}, bar: 10}`.
 * Supports some of the named comparision operators ($type, $size and $all).  For example, `foo:type=string`, yeilds `{ foo: {$type: 'string} }`.
-* Support for forced string comparison; value in single or double quotes (`field='10'` or `field="10"`) would force a string compare. Allows for string with embedded comma (`field="a,b"`) and quotes (`field="that's all folks"`).
+* Support for forced string comparison; value in single or double quotes (`$field='10'` or `field="10"`) would force a string compare. Allows for string with embedded comma (`field="a,b"`) and quotes (`field="that's all folks"`).
 
 ### A note on embedded documents
 Comparisons on embedded documents should use mongo's [dot notation](http://docs.mongodb.org/manual/reference/glossary/#term-dot-notation) instead of express's 'extended' [query parser](https://www.npmjs.com/package/qs) (Use `foo.bar=value` instead of `foo[bar]=value`).

--- a/index.js
+++ b/index.js
@@ -182,9 +182,9 @@ function queryCriteriaToMongo(query, options) {
 // for example {fields:'a,b',offset:8,limit:16} becomes {fields:{a:true,b:true},skip:8,limit:16}
 function queryOptionsToMongo(query, options) {
     var hash = {},
-        fields = fieldsToMongo(query.fields),
-        omitFields = omitFieldsToMongo(query.omit),
-        sort = sortToMongo(query.sort),
+        fields = fieldsToMongo(query.$fields),
+        omitFields = omitFieldsToMongo(query.$omit),
+        sort = sortToMongo(query.$sort),
         maxLimit = options.maxLimit || 9007199254740992,
         limit = options.maxLimit || 0
 
@@ -194,8 +194,8 @@ function queryOptionsToMongo(query, options) {
     if (omitFields) hash.fields = omitFields
     if (sort) hash.sort = sort
 
-    if (query.offset) hash.skip = Number(query.offset)
-    if (query.limit) limit = Math.min(Number(query.limit), maxLimit)
+    if (query.$offset) hash.skip = Number(query.$offset)
+    if (query.$limit) limit = Math.min(Number(query.$limit), maxLimit)
     if (limit) {
         hash.limit = limit
     } else if (options.maxLimit) {
@@ -214,7 +214,7 @@ module.exports = function(query, options) {
     } else {
         options.ignore = (typeof options.ignore === 'string') ? [options.ignore] : options.ignore
     }
-    options.ignore = options.ignore.concat(['fields', 'omit', 'sort', 'offset', 'limit'])
+    options.ignore = options.ignore.concat(['$fields', '$omit', '$sort', '$offset', '$limit'])
     if (!options.parser) options.parser = querystring
 
     if (typeof query === 'string') query = options.parser.parse(query)
@@ -234,18 +234,18 @@ module.exports = function(query, options) {
             options = options || {}
 
             if (offset > 0) {
-                query.offset = Math.max(offset - limit, 0)
+                query.$offset = Math.max(offset - limit, 0)
                 links['prev'] = url + '?' + options.parser.stringify(query)
-                query.offset = 0
+                query.$offset = 0
                 links['first'] = url + '?' + options.parser.stringify(query)
             }
             if (offset + limit < totalCount) {
                 last.pages = Math.ceil(totalCount / limit)
                 last.offset = (last.pages - 1) * limit
 
-                query.offset = Math.min(offset + limit, last.offset)
+                query.$offset = Math.min(offset + limit, last.offset)
                 links['next'] = url  + '?' + options.parser.stringify(query)
-                query.offset = last.offset
+                query.$offset = last.offset
                 links['last'] = url  + '?' + options.parser.stringify(query)
             }
             return links

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,191 @@
+{
+  "name": "query-to-mongo",
+  "version": "0.9.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+      "dev": true
+    },
+    "chai": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-2.3.0.tgz",
+      "integrity": "sha1-ii9qNHSNqAEJD9cyh7Kqc5pOkJo=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.0",
+        "deep-eql": "0.1.3"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimatch": "0.3.0"
+      }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "dev": true
+    }
+  }
+}

--- a/test/links.js
+++ b/test/links.js
@@ -3,22 +3,22 @@ var q2m = require("../index")
 
 describe("query-to-mongo(query).links =>", function () {
     describe("#links", function () {
-        var links = q2m("offset=20&limit=10").links('http://localhost', 95)
+        var links = q2m("$offset=20&$limit=10").links('http://localhost', 95)
         it("should create first link", function () {
-            assert.equal(links.first, "http://localhost?offset=0&limit=10")
+            assert.equal(links.first, "http://localhost?%24offset=0&%24limit=10")
         })
         it("should create prev link", function () {
-            assert.equal(links.prev, "http://localhost?offset=10&limit=10")
+            assert.equal(links.prev, "http://localhost?%24offset=10&%24limit=10")
         })
         it("should create next link", function () {
-            assert.equal(links.next, "http://localhost?offset=30&limit=10")
+            assert.equal(links.next, "http://localhost?%24offset=30&%24limit=10")
         })
         it("should create last link", function () {
-            assert.equal(links.last, "http://localhost?offset=90&limit=10")
+            assert.equal(links.last, "http://localhost?%24offset=90&%24limit=10")
         })
 
         describe("with no pages", function () {
-            var links = q2m("offset=0&limit=100").links('http://localhost', 95)
+            var links = q2m("$offset=0&$limit=100").links('http://localhost', 95)
             it("should not create links", function () {
                 assert.notOk(links.first)
                 assert.notOk(links.last)
@@ -27,7 +27,7 @@ describe("query-to-mongo(query).links =>", function () {
             })
         })
         describe("when on first page", function () {
-            var links = q2m("offset=0&limit=10").links('http://localhost', 95)
+            var links = q2m("$offset=0&$limit=10").links('http://localhost', 95)
             it("should not create prev link", function () {
                 assert.notOk(links.prev)
             })
@@ -35,14 +35,14 @@ describe("query-to-mongo(query).links =>", function () {
                 assert.notOk(links.first)
             })
             it("should create next link", function () {
-                assert.equal(links.next, "http://localhost?offset=10&limit=10")
+                assert.equal(links.next, "http://localhost?%24offset=10&%24limit=10")
             })
             it("should create last link", function () {
-                assert.equal(links.last, "http://localhost?offset=90&limit=10")
+                assert.equal(links.last, "http://localhost?%24offset=90&%24limit=10")
             })
         })
         describe("when on last page", function () {
-            var links = q2m("offset=90&limit=10").links('http://localhost', 95)
+            var links = q2m("$offset=90&$limit=10").links('http://localhost', 95)
             it("should not create next link", function () {
                 assert.notOk(links.next)
             })
@@ -50,10 +50,10 @@ describe("query-to-mongo(query).links =>", function () {
                 assert.notOk(links.last)
             })
             it("should create prev link", function () {
-                assert.equal(links.prev, "http://localhost?offset=80&limit=10")
+                assert.equal(links.prev, "http://localhost?%24offset=80&%24limit=10")
             })
             it("should not create first link", function () {
-                assert.equal(links.first, "http://localhost?offset=0&limit=10")
+                assert.equal(links.first, "http://localhost?%24offset=0&%24limit=10")
             })
         })
     })

--- a/test/qs.js
+++ b/test/qs.js
@@ -39,40 +39,40 @@ describe("query-to-mongo(query,{paser: qs}) =>", function () {
 
     describe(".options", function () {
         it("should create paging options", function () {
-            var results = q2m("offset=8&limit=16", {parser: qs})
+            var results = q2m("$offset=8&$limit=16", {parser: qs})
             assert.ok(results.options)
             assert.deepEqual(results.options, {skip: 8, limit: 16})
         })
         it("should create field option", function () {
-            var results = q2m("fields=a,b,c", {parser: qs})
+            var results = q2m("$fields=a,b,c", {parser: qs})
             assert.ok(results.options)
             assert.deepEqual(results.options, {fields: {a:1, b:1, c:1}})
         })
         it("should create sort option", function () {
-            var results = q2m("sort=a,+b,-c", {parser: qs})
+            var results = q2m("$sort=a,+b,-c", {parser: qs})
             assert.ok(results.options)
             assert.deepEqual(results.options, {sort: {a:1, b:1, c:-1}})
         })
         it("should limit queries", function () {
-            var results = q2m("limit=100", {maxLimit: 50, parser: qs})
+            var results = q2m("$limit=100", {maxLimit: 50, parser: qs})
             assert.ok(results.options)
             assert.deepEqual(results.options, {limit: 50})
         })
     })
 
     describe("#links", function () {
-        var links = q2m("foo[bar]=baz&offset=20&limit=10", {maxLimit: 50, parser: qs}).links('http://localhost', 100)
+        var links = q2m("foo[bar]=baz&$offset=20&$limit=10", {maxLimit: 50, parser: qs}).links('http://localhost', 100)
         it("should create first link", function () {
-            assert.equal(links.first, "http://localhost?foo%5Bbar%5D=baz&offset=0&limit=10")
+            assert.equal(links.first, "http://localhost?foo%5Bbar%5D=baz&%24offset=0&%24limit=10")
         })
         it("should create prev link", function () {
-            assert.equal(links.prev, "http://localhost?foo%5Bbar%5D=baz&offset=10&limit=10")
+            assert.equal(links.prev, "http://localhost?foo%5Bbar%5D=baz&%24offset=10&%24limit=10")
         })
         it("should create next link", function () {
-            assert.equal(links.next, "http://localhost?foo%5Bbar%5D=baz&offset=30&limit=10")
+            assert.equal(links.next, "http://localhost?foo%5Bbar%5D=baz&%24offset=30&%24limit=10")
         })
         it("should create last link", function () {
-            assert.equal(links.last, "http://localhost?foo%5Bbar%5D=baz&offset=90&limit=10")
+            assert.equal(links.last, "http://localhost?foo%5Bbar%5D=baz&%24offset=90&%24limit=10")
         })
     })
 })

--- a/test/query.js
+++ b/test/query.js
@@ -163,13 +163,13 @@ describe("query-to-mongo(query) =>", function () {
             assert.deepEqual(results.criteria, {field: {"$gte": 10, "$lte": 20}})
         })
         it("should ignore criteria", function () {
-            var results = q2m("field=value&envelope=true&&offset=0&limit=10&fields=id&sort=name", { ignore: ['envelope']})
+            var results = q2m("field=value&envelope=true&&$offset=0&$limit=10&$fields=id&$sort=name", { ignore: ['envelope']})
             assert.ok(results.criteria)
             assert.notOk(results.criteria.envelope, "envelope")
-            assert.notOk(results.criteria.skip, "offset")
-            assert.notOk(results.criteria.limit, "limit")
-            assert.notOk(results.criteria.fields, "fields")
-            assert.notOk(results.criteria.sort, "sort")
+            assert.notOk(results.criteria.skip, "$offset")
+            assert.notOk(results.criteria.limit, "$limit")
+            assert.notOk(results.criteria.fields, "$fields")
+            assert.notOk(results.criteria.sort, "$sort")
             assert.deepEqual(results.criteria, {field: "value"})
         })
         it("should create $exists criteria from value", function () {
@@ -221,32 +221,32 @@ describe("query-to-mongo(query) =>", function () {
 
     describe(".options", function () {
         it("should create paging options", function () {
-            var results = q2m("offset=8&limit=16")
+            var results = q2m("$offset=8&$limit=16")
             assert.ok(results.options)
             assert.deepEqual(results.options, {skip: 8, limit: 16})
         })
         it("should create field option", function () {
-            var results = q2m("fields=a,b,c")
+            var results = q2m("$fields=a,b,c")
             assert.ok(results.options)
             assert.deepEqual(results.options, {fields: {a:1, b:1, c:1}})
         })
         it("should create omit option", function () {
-            var results = q2m("omit=b")
+            var results = q2m("$omit=b")
             assert.ok(results.options)
             assert.deepEqual(results.options, {fields: {b:0}})
         })
         it("should create omit option", function () {
-            var results = q2m("omit=b")
+            var results = q2m("$omit=b")
             assert.ok(results.options)
             assert.deepEqual(results.options, {fields: {b:0}})
         })
         it("should create sort option", function () {
-            var results = q2m("sort=a,+b,-c")
+            var results = q2m("$sort=a,+b,-c")
             assert.ok(results.options)
             assert.deepEqual(results.options, {sort: {a:1, b:1, c:-1}})
         })
         it("should limit queries", function () {
-            var results = q2m("limit=100", {maxLimit: 50})
+            var results = q2m("$limit=100", {maxLimit: 50})
             assert.ok(results.options)
             assert.deepEqual(results.options, {limit: 50})
         })


### PR DESCRIPTION
People may use 'fields', 'omit' as database field's name. So, to fix the collision of name, I add '$' at the beginning of all the operators for options. 
They become: $fields, $omit, $sort, $offset and $limit
Also I have already changed all the documentation