### PR TITLE
Improve queryToMongo function types to allow call without types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,6 +15,8 @@ declare module 'query-to-mongo' {
     link: Function
   }
 
-  export function queryToMongo<T>(query: T, options?: QueryToMongoOptions): QueryToMongoResult<T>;
+  function queryToMongo<T>(query: T, options?: QueryToMongoOptions): QueryToMongoResult<T>;
+
+  export = queryToMongo;
   
 }


### PR DESCRIPTION
Improve queryToMongo function types to allow call without types