### PR TITLE
fix: skip __proto__/constructor/prototype keys (prototype pollution)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 var querystring = require('querystring')
 var iso8601 = require('./lib/iso8601-regex')
 
+// Field names that must never be used as an object key, because writing
+// through them mutates Object.prototype for the whole process.
+var FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype']
+
 // Convert comma separated list to a mongo projection.
 // for example f('field1,field2,field3') -> {field1:true,field2:true,field3:true}
 function fieldsToMongo(fields) {
@@ -155,6 +159,10 @@ function queryCriteriaToMongo(query, options) {
     options = options || {}
 
     for (var key in query) {
+        // Keys that walk into Object.prototype are always skipped: assigning to
+        // hash['__proto__'] writes through the prototype getter and mutates
+        // Object.prototype for the whole process (prototype pollution).
+        if (FORBIDDEN_KEYS.indexOf(key) !== -1) continue
         if (Object.prototype.hasOwnProperty.call(query, key) && (!options.ignore || options.ignore.indexOf(key) == -1)) {
             deep = (typeof query[key] === 'object' && !hasOrdinalKeys(query[key]))
 


### PR DESCRIPTION
### Summary

`queryCriteriaToMongo()` merges each field into an accumulator using the field
name as the key, with no guard on prototype-walking names:

```js
if (!hash[p.key]) {
    hash[p.key] = p.value;
} else {
    hash[p.key] = Object.assign(hash[p.key], p.value);
}
```

When `p.key` is `__proto__`, `hash['__proto__']` resolves through the prototype
getter to `Object.prototype`, so the second branch becomes
`Object.assign(Object.prototype, p.value)` — copying every attacker-controlled
key and value onto the prototype of every object in the process (CWE-1321
prototype pollution).

Reproduced on 0.12.2:

```js
q2m(JSON.parse('{"__proto__":{"polluted":"YES"}}'));
({}).polluted   // => 'YES'

// the deep branch recurses, so nested objects reach the same sink:
q2m(JSON.parse('{"foo":{"__proto__":{"polluted":"YES"}}}'));
({}).polluted   // => 'YES'
```

Unlike operator-limited pollution, **both the key and the value are
attacker-controlled** here, so this can set arbitrary gadget properties.

Reachability note: Express's default `qs` parser strips `__proto__`, so the
common `q2m(req.query)` path is protected by the parser rather than by this
library. But `q2m()` is routinely handed objects from JSON bodies, custom or
non-`qs` nested parsers, and other sources, and the library itself provides no
guard — so the sink is worth closing here.

### Fix

Skip the three prototype-walking names in the field loop, next to the existing
`options.ignore` check. They are not usable field names, so no legitimate query
is affected.

```js
var FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype']
...
if (FORBIDDEN_KEYS.indexOf(key) !== -1) continue
```

### Verification

- Existing test suite passes unchanged (`jest`, **93 tests passed**, 4 suites).
- Flat `__proto__`, nested `__proto__`, and `constructor` payloads no longer
  pollute — `({}).polluted` stays `undefined` in all three cases.
- Normal queries are unchanged, e.g.
  `q2m('name=john&age>21&fields=name,age&limit=10')` still yields
  `{"criteria":{"name":"john","age":{"$gt":21}},"options":{"fields":{"name":1,"age":1},"limit":10}}`.

### Notes

Found and fixed with AI assistance (Claude). Happy to add a regression test if
you'd like one.
